### PR TITLE
feat: 記事削除機能 #3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Add
 
+- feat: 記事削除機能 #3
 - feat: ログアウト機能 #2
 
 ## Change

--- a/backend/api.yaml
+++ b/backend/api.yaml
@@ -142,6 +142,32 @@ paths:
           $ref: '#/components/responses/NotFoundError' 
         '500':
           $ref: '#/components/responses/InternalError' 
+    delete:
+      summary: Delete a specific article
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id 
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Article deleted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                example: {}
+        '400':
+          $ref: '#/components/responses/BadRequest' 
+        '401':
+          $ref: '#/components/responses/UnauthorizedError' 
+        '404':
+          $ref: '#/components/responses/NotFoundError' 
+        '500':
+          $ref: '#/components/responses/InternalError' 
   /signup:
     post:
       summary: Create a user 

--- a/backend/api/delete_article.py
+++ b/backend/api/delete_article.py
@@ -1,0 +1,44 @@
+from logging import getLogger
+from flask import Flask, jsonify
+from pynamodb.exceptions import DoesNotExist
+from db.rds import Articles, db
+from db.dynamodb import ArticleDetails
+from flask_jwt_extended import get_jwt_identity
+
+log = getLogger(__name__)
+
+def delete_article_by_id(app: Flask, id: int):
+    try:
+        user_id = get_jwt_identity()
+
+        with app.app_context():
+
+            article = (
+                db.session.query(Articles).get(id)
+            )
+
+            if not article:
+                return (
+                    jsonify({"message": "Resource not found"}),
+                    404,
+                )
+
+            db.session.delete(article)
+
+            try:
+                db.session.flush()
+                ArticleDetails(id=article.id, details=article).delete()
+                db.session.commit()
+                return (
+                    jsonify({"message": "Article deleted successfully."}),
+                    200,
+                )
+            except DoesNotExist:
+                return (
+                    jsonify({"message": "Resource not found"}),
+                    404,
+                )
+
+    except Exception as e:
+        log.error(e)
+        return jsonify({"message": "Internal Server Error"}), 500

--- a/backend/app.py
+++ b/backend/app.py
@@ -10,6 +10,7 @@ from api.create_article import create_article
 from api.get_articles import get_article_by_id
 from api.update_article import update_article
 from api.list_articles import list_articles
+from api.delete_article import delete_article_by_id
 from db.rds import Config, db
 from utils.init_db import init_dynamodb, init_rds
 
@@ -52,6 +53,11 @@ def get_article_by_id_end_point(id: int):
 @jwt_required()
 def update_article_endpoint(id: int):
     return update_article(app, id)
+
+@app.route("/posts/<int:id>", methods=["DELETE"])
+@jwt_required()
+def delete_article_by_id_endpoint(id: int):
+    return delete_article_by_id(app, id)
 
 @app.cli.command("init-rds")
 def init_rds_endpoint():

--- a/frontend/src/components/Modatal.tsx
+++ b/frontend/src/components/Modatal.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+export type ModalProps = {
+  open: boolean;
+  onNegative: () => void;
+  onPositive: () => void;
+  title: string;
+  message: string;
+  labelPositive?: string;
+  labelNegative?: string;
+};
+
+const Modal = ({
+  open,
+  onNegative,
+  onPositive,
+  title,
+  message,
+  labelPositive = 'OK',
+  labelNegative = 'キャンセル',
+}: ModalProps) => {
+  return open ? (
+    <>
+      <div className="absolute left-1/2 top-1/2 z-20 flex h-48 w-80 -translate-x-1/2 -translate-y-1/2 transform flex-col items-start bg-white p-5">
+        <h1 className="mb-5 text-xl font-bold">{title}</h1>
+        <p className="mb-5 text-lg">{message}</p>
+        <div className="mt-auto flex w-full">
+          <button
+            className="mx-auto bg-slate-900 px-8 py-2 text-white hover:bg-slate-700"
+            onClick={() => onNegative()}
+          >
+            {labelNegative}
+          </button>
+          <button
+            className="mx-auto bg-slate-900 px-8 py-2 text-white hover:bg-slate-700"
+            onClick={() => onPositive()}
+          >
+            {labelPositive}
+          </button>
+        </div>
+      </div>
+      <div
+        className="fixed z-10 h-full w-full bg-black bg-opacity-50"
+        onClick={() => onNegative()}
+      ></div>
+    </>
+  ) : (
+    <></>
+  );
+};
+
+export default Modal;

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,5 +1,4 @@
 import { http, HttpResponse } from 'msw';
-import { title } from 'process';
 
 export const handlers = [
   http.get('api/posts', () => {
@@ -67,6 +66,10 @@ export const handlers = [
   }),
 
   http.put('api/posts/1', () => {
+    return HttpResponse.json();
+  }),
+
+  http.delete('api/posts/1', () => {
     return HttpResponse.json();
   }),
 


### PR DESCRIPTION
## frontend
- 確認用ダイアログの実装
- 記事編集画面にて、記事の削除ボタンを追加
- ダイアログで削除するが押されたら削除APIを実行する

## backend
- 削除APIをyamlに追加
- 削除APIの実装